### PR TITLE
Fix resource group update operation

### DIFF
--- a/opsramp/resource_groups.py
+++ b/opsramp/resource_groups.py
@@ -36,8 +36,7 @@ class ResourceGroups(ORapi):
         return self.api.post(url_suffix, json=definition)
 
     def update(self, uuid, definition):
-        # Specify the UUID in the request body.
-        definition["id"] = uuid
+        # The UUID(s) already specified in the request body(ies).
         return self.api.post("", json=definition)
 
     def delete(self, uuid):

--- a/opsramp/resource_groups.py
+++ b/opsramp/resource_groups.py
@@ -35,9 +35,9 @@ class ResourceGroups(ORapi):
         url_suffix = ""
         return self.api.post(url_suffix, json=definition)
 
-    def update(self, uuid, definition):
-        # The UUID(s) already specified in the request body(ies).
-        return self.api.post("", json=definition)
+    def update(self, definition):
+        # UUID(s) specified in the request body(ies).
+        return self.api.post(json=definition)
 
     def delete(self, uuid):
         url_suffix = uuid

--- a/opsramp/resource_groups.py
+++ b/opsramp/resource_groups.py
@@ -36,8 +36,9 @@ class ResourceGroups(ORapi):
         return self.api.post(url_suffix, json=definition)
 
     def update(self, uuid, definition):
-        url_suffix = uuid
-        return self.api.post(url_suffix, json=definition)
+        # Specify the UUID in the request body.
+        definition["id"] = uuid
+        return self.api.post("", json=definition)
 
     def delete(self, uuid):
         url_suffix = uuid

--- a/tests/test_resource_grps.py
+++ b/tests/test_resource_grps.py
@@ -64,7 +64,7 @@ class ApiTest(unittest.TestCase):
         fake_update_json = {"os": "Ubuntu 18.04.4 LTS"}
         fake_result = {"id": fake_resource_id}
         with requests_mock.Mocker() as m:
-            url = group.api.compute_url(fake_resource_id)
+            url = group.api.compute_url("")
             m.post(url, json=fake_result, complete_qs=True)
             actual = group.update(uuid=fake_resource_id, definition=fake_update_json)
             assert actual == fake_result

--- a/tests/test_resource_grps.py
+++ b/tests/test_resource_grps.py
@@ -42,16 +42,16 @@ class ApiTest(unittest.TestCase):
 
     def test_create(self):
         group = self.client.resource_groups()
-        fake_create_json = {
+        fake_create_json = [{
             "resourceName": "ABBY-PC",
             "hostName": "ABBY-PC",
             "aliasName": "Server PC",
             "resourceType": "server",
             "os": "Ubuntu 14.04.6 LTS",
             "serialNumber": "1234-5678-901234",
-        }
+        }]
         thisid = 333333
-        fake_result = {"id": thisid}
+        fake_result = [{"id": thisid}]
         with requests_mock.Mocker() as m:
             url = group.api.compute_url()
             m.post(url, json=fake_result, complete_qs=True)
@@ -61,12 +61,12 @@ class ApiTest(unittest.TestCase):
     def test_update(self):
         group = self.client.resource_groups()
         fake_resource_id = "123456"
-        fake_update_json = {"os": "Ubuntu 18.04.4 LTS"}
-        fake_result = {"id": fake_resource_id}
+        fake_update_json = [{"id": fake_resource_id, "os": "Ubuntu 18.04.4 LTS"}]
+        fake_result = fake_update_json
         with requests_mock.Mocker() as m:
             url = group.api.compute_url("")
             m.post(url, json=fake_result, complete_qs=True)
-            actual = group.update(uuid=fake_resource_id, definition=fake_update_json)
+            actual = group.update(uuid="", definition=fake_update_json)
             assert actual == fake_result
 
     def test_delete(self):

--- a/tests/test_resource_grps.py
+++ b/tests/test_resource_grps.py
@@ -42,14 +42,16 @@ class ApiTest(unittest.TestCase):
 
     def test_create(self):
         group = self.client.resource_groups()
-        fake_create_json = [{
-            "resourceName": "ABBY-PC",
-            "hostName": "ABBY-PC",
-            "aliasName": "Server PC",
-            "resourceType": "server",
-            "os": "Ubuntu 14.04.6 LTS",
-            "serialNumber": "1234-5678-901234",
-        }]
+        fake_create_json = [
+            {
+                "resourceName": "ABBY-PC",
+                "hostName": "ABBY-PC",
+                "aliasName": "Server PC",
+                "resourceType": "server",
+                "os": "Ubuntu 14.04.6 LTS",
+                "serialNumber": "1234-5678-901234",
+            }
+        ]
         thisid = 333333
         fake_result = [{"id": thisid}]
         with requests_mock.Mocker() as m:

--- a/tests/test_resource_grps.py
+++ b/tests/test_resource_grps.py
@@ -62,13 +62,12 @@ class ApiTest(unittest.TestCase):
 
     def test_update(self):
         group = self.client.resource_groups()
-        fake_resource_id = "123456"
-        fake_update_json = [{"id": fake_resource_id, "os": "Ubuntu 18.04.4 LTS"}]
+        fake_update_json = [{"id": "123456", "os": "Ubuntu 18.04.4 LTS"}]
         fake_result = fake_update_json
         with requests_mock.Mocker() as m:
-            url = group.api.compute_url("")
+            url = group.api.compute_url()
             m.post(url, json=fake_result, complete_qs=True)
-            actual = group.update(uuid="", definition=fake_update_json)
+            actual = group.update(definition=fake_update_json)
             assert actual == fake_result
 
     def test_delete(self):


### PR DESCRIPTION
The resource 'update' operation follows the same pattern as RBA update.

The `id` of the resource to update is embedded in the JSON, not appended to the URL.